### PR TITLE
タバコ登録コントローラー作成

### DIFF
--- a/app/controllers/smoker/cigarettes_controller.rb
+++ b/app/controllers/smoker/cigarettes_controller.rb
@@ -1,0 +1,46 @@
+class Smoker::CigarettesController < ApplicationController
+  before_action :set_cigarette, only: [:edit, :update, :destroy]
+
+  def index
+    @cigarettes = current_user.cigarettes.order(created_at: :desc)
+    @new_cigarette = current_user.cigarettes.build
+  end
+
+  def create
+    @cigarette = current_user.cigarettes.build(cigarette_params)
+    if @cigarette.save
+      redirect_to smoker_cigarettes_path, notice: 'タバコが正常に登録されました。'
+    else
+      @cigarettes = current_user.cigarettes.order(created_at: :desc)
+      flash.now[:alert] = 'タバコの登録に失敗しました。'
+      render :index
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @cigarette.update(cigarette_params)
+      redirect_to smoker_cigarettes_path, notice: 'タバコ情報が更新されました。'
+    else
+      flash.now[:alert] = 'タバコ情報の更新に失敗しました。'
+      render :edit
+    end
+  end
+
+  def destroy
+    @cigarette.destroy!
+    redirect_to smoker_cigarettes_path, notice: 'タバコ情報が削除されました。'
+  end
+
+  private
+
+  def set_cigarette
+    @cigarette = current_user.cigarettes.find(params[:id])
+  end
+
+  def cigarette_params
+    params.require(:cigarette).permit(:brand, :quantity_per_pack, :price_per_pack)
+  end
+end

--- a/app/views/smoker/cigarettes/index.html.erb
+++ b/app/views/smoker/cigarettes/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Smoker::Cigarettes#index</h1>
+<p>Find me in app/views/smoker/cigarettes/index.html.erb</p>

--- a/app/views/smoker/cigarettes/new.html.erb
+++ b/app/views/smoker/cigarettes/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Smoker::Cigarettes#new</h1>
+<p>Find me in app/views/smoker/cigarettes/new.html.erb</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,10 @@ Rails.application.routes.draw do
   resources :tops, only: [:index]
   resources :users, only: [:new, :create]
 
+  namespace :smoker do
+    resources :cigarettes, only: [:index, :create, :edit, :update, :destroy]
+  end
+
   get 'login', to: 'user_sessions#new', as: :login
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy', as: :logout


### PR DESCRIPTION
### タバコ登録コントローラーの作成

1. index
  - 現在のユーザーのタバコ情報を降順で表示
  - 新規登録用のフォームを同ページ内で表示
  
2. create
  - 新しいタバコ情報を登録
  - 正常に登録された場合、タバコ一覧ページにリダイレクトし、成功メッセージを表示
  - 登録に失敗した場合、エラーメッセージを表示し、再度入力を促す

3. edit
  - 既存のタバコ情報を編集するためのフォームを表示

4. update
  - タバコ情報の更新
  - 正常に更新された場合、タバコ一覧ページにリダイレクトし、成功メッセージを表示
  - 更新に失敗した場合、エラーメッセージを表示し、再度編集を促す

5. destroy
  - タバコ情報を削除
  - 削除後、タバコ一覧ページにリダイレクトし、成功メッセージを表示
  - 失敗を考慮していない作りとする